### PR TITLE
feat: add mqtt power-up notifications

### DIFF
--- a/backend/BattleTanks-Backend/Application/DTOs/PlayerScoreDtos.cs
+++ b/backend/BattleTanks-Backend/Application/DTOs/PlayerScoreDtos.cs
@@ -1,0 +1,16 @@
+namespace Application.DTOs;
+
+public record PlayerScoredDto(
+    string PlayerId,
+    int Score
+);
+
+public record PlayerScoreDto(
+    string PlayerId,
+    int Score
+);
+
+public record GameEndedDto(
+    string WinnerPlayerId,
+    List<PlayerScoreDto> Scores
+);

--- a/backend/BattleTanks-Backend/Application/DTOs/PowerUpDto.cs
+++ b/backend/BattleTanks-Backend/Application/DTOs/PowerUpDto.cs
@@ -1,0 +1,14 @@
+namespace Application.DTOs;
+
+public enum PowerUpType
+{
+    ExtraLife
+}
+
+public record PowerUpDto(
+    string Id,
+    string RoomId,
+    PowerUpType Type,
+    float X,
+    float Y
+);

--- a/backend/BattleTanks-Backend/Application/Interfaces/IGameService.cs
+++ b/backend/BattleTanks-Backend/Application/Interfaces/IGameService.cs
@@ -6,6 +6,7 @@ public interface IGameService
 {
     Task<RoomStateDto?> CreateRoom(string userId, CreateRoomDto createRoomDto);
     Task<RoomStateDto?> JoinRoom(string userId, string connectionId, JoinRoomDto joinRoomDto);
+    Task<RoomStateDto?> StartGame(string roomId);
     Task<bool> LeaveRoom(string userId, string roomId);
     Task<bool> UpdatePlayerPosition(string roomId, string userId, PlayerPositionDto positionDto);
     Task<PlayerStateDto?> GetPlayerPosition(string roomId, string userId);

--- a/backend/BattleTanks-Backend/Application/Interfaces/IGameService.cs
+++ b/backend/BattleTanks-Backend/Application/Interfaces/IGameService.cs
@@ -15,4 +15,8 @@ public interface IGameService
     Task<RoomStateDto?> GetRoomByCode(string roomCode);
     Task<PlayerStateDto?> GetPlayerState(string roomId, string userId);
     Task<List<RoomStateDto>> GetActiveRooms();
+
+    Task AwardWallPoints(string roomId, string userId, int points);
+    Task RegisterKill(string roomId, string shooterId, string targetId, int points);
+    Task EndGame(string roomId);
 }

--- a/backend/BattleTanks-Backend/Application/Interfaces/IMapService.cs
+++ b/backend/BattleTanks-Backend/Application/Interfaces/IMapService.cs
@@ -13,4 +13,6 @@ public interface IMapService
     bool TryGetTile(string roomId, int tx, int ty, out MapTileDto tile);
     bool TryDamageDestructible(string roomId, int tx, int ty, out MapTileDto updated);
     bool IsSolid(string roomId, int tx, int ty);
+
+    (float x, float y)[] GetSpawnPoints(string roomId);
 }

--- a/backend/BattleTanks-Backend/Application/Interfaces/IPowerUpService.cs
+++ b/backend/BattleTanks-Backend/Application/Interfaces/IPowerUpService.cs
@@ -1,0 +1,10 @@
+using Application.DTOs;
+
+namespace Application.Interfaces;
+
+public interface IPowerUpService
+{
+    PowerUpDto SpawnRandom(string roomCode, string roomId);
+    IReadOnlyCollection<PowerUpDto> GetActive(string roomCode);
+    bool TryConsume(string roomCode, string userId, float x, float y, out PowerUpDto? powerUp);
+}

--- a/backend/BattleTanks-Backend/Application/Services/GameService.cs
+++ b/backend/BattleTanks-Backend/Application/Services/GameService.cs
@@ -11,17 +11,20 @@ public class GameService : IGameService
     private readonly IPlayerRepository _playerRepository;
     private readonly IUserRepository _userRepository;
     private readonly IGameNotificationService _notificationService;
+    private readonly IScoreRepository _scoreRepository;
 
     public GameService(
         IGameSessionRepository gameSessionRepository,
         IPlayerRepository playerRepository,
         IUserRepository userRepository,
-        IGameNotificationService notificationService)
+        IGameNotificationService notificationService,
+        IScoreRepository scoreRepository)
     {
         _gameSessionRepository = gameSessionRepository;
         _playerRepository = playerRepository;
         _userRepository = userRepository;
         _notificationService = notificationService;
+        _scoreRepository = scoreRepository;
     }
 
     public async Task<RoomStateDto?> CreateRoom(string userId, CreateRoomDto createRoomDto)
@@ -228,6 +231,59 @@ public class GameService : IGameService
     {
         var sessions = await _gameSessionRepository.GetActiveSessionsAsync();
         return sessions.Select(MapToRoomStateDto).ToList();
+    }
+
+    public async Task AwardWallPoints(string roomId, string userId, int points)
+    {
+        if (!Guid.TryParse(roomId, out var roomGuid) || !Guid.TryParse(userId, out var userGuid)) return;
+        var session = await _gameSessionRepository.GetByIdAsync(roomGuid);
+        var player = session?.GetPlayer(userGuid);
+        if (player is null) return;
+        player.AddScore(points);
+        await _playerRepository.UpdateAsync(player);
+    }
+
+    public async Task RegisterKill(string roomId, string shooterId, string targetId, int points)
+    {
+        if (!Guid.TryParse(roomId, out var roomGuid) ||
+            !Guid.TryParse(shooterId, out var shooterGuid) ||
+            !Guid.TryParse(targetId, out var targetGuid)) return;
+
+        var session = await _gameSessionRepository.GetByIdAsync(roomGuid);
+        if (session is null) return;
+        var shooter = session.GetPlayer(shooterGuid);
+        var target = session.GetPlayer(targetGuid);
+        if (shooter is null || target is null) return;
+
+        shooter.AddKill(points);
+        target.TakeDamage(100);
+        await _playerRepository.UpdateAsync(shooter);
+        await _playerRepository.UpdateAsync(target);
+        await _gameSessionRepository.UpdateAsync(session);
+    }
+
+    public async Task EndGame(string roomId)
+    {
+        if (!Guid.TryParse(roomId, out var roomGuid)) return;
+        var session = await _gameSessionRepository.GetByIdAsync(roomGuid);
+        if (session is null) return;
+
+        session.EndGame();
+        await _gameSessionRepository.UpdateAsync(session);
+
+        foreach (var score in session.Scores)
+        {
+            await _scoreRepository.AddAsync(score);
+            var user = await _userRepository.GetByIdAsync(score.UserId);
+            if (user != null)
+            {
+                user.AddGameResult(score.IsWinner, score.Points);
+                await _userRepository.UpdateAsync(user);
+            }
+        }
+
+        var roomState = MapToRoomStateDto(session);
+        await _notificationService.NotifyRoomStateChanged(roomId, roomState);
     }
 
     private RoomStateDto MapToRoomStateDto(GameSession session)

--- a/backend/BattleTanks-Backend/BattleTanks-Backend/appsettings.json
+++ b/backend/BattleTanks-Backend/BattleTanks-Backend/appsettings.json
@@ -24,5 +24,10 @@
     "MapWidthPx": 800,
     "MapHeightPx": 600,
     "TileSize": 40
+  },
+  "MqttSettings": {
+    "Host": "mqtt",
+    "Port": 1883,
+    "TopicPrefix": "battletanks"
   }
 }

--- a/backend/BattleTanks-Backend/Domain/Entities/Player.cs
+++ b/backend/BattleTanks-Backend/Domain/Entities/Player.cs
@@ -89,6 +89,11 @@ public class Player
         SessionKills++;
         SessionScore += points;
     }
+
+    public void AddScore(int points)
+    {
+        SessionScore += points;
+    }
     
     public void ResetSessionStats()
     {

--- a/backend/BattleTanks-Backend/Infrastructure/Background/BulletSimulationService.cs
+++ b/backend/BattleTanks-Backend/Infrastructure/Background/BulletSimulationService.cs
@@ -16,9 +16,11 @@ public class BulletSimulationService : BackgroundService
     private readonly IMapService _map;
     private readonly IRoomRegistry _rooms;
     private readonly IHubContext<GameHub> _hub;
+    private readonly IGameService _game;
 
 
     private readonly Dictionary<string, Dictionary<string, int>> _lives = new();
+    private readonly Dictionary<string, Dictionary<string, int>> _scores = new();
 
     private const float BulletRadius = 2.5f;
     private const float TankHalfW = 12f;
@@ -29,13 +31,15 @@ public class BulletSimulationService : BackgroundService
         IBulletService bullets,
         IMapService map,
         IRoomRegistry rooms,
-        IHubContext<GameHub> hub)
+        IHubContext<GameHub> hub,
+        IGameService game)
     {
         _log = log;
         _bullets = bullets;
         _map = map;
         _rooms = rooms;
         _hub = hub;
+        _game = game;
     }
 
     protected override async Task ExecuteAsync(CancellationToken stoppingToken)
@@ -103,6 +107,14 @@ public class BulletSimulationService : BackgroundService
                         type = (int)updated.Type,
                         hp = updated.Hp
                     });
+
+                    var scores = GetScoreDict(snap.RoomId);
+                    var sc = scores.TryGetValue(b.ShooterId, out var prevScore) ? prevScore : 0;
+                    sc += 50;
+                    scores[b.ShooterId] = sc;
+                    _ = _hub.Clients.Group(roomCode).SendAsync("playerScored",
+                        new PlayerScoredDto(b.ShooterId, sc));
+                    _ = _game.AwardWallPoints(snap.RoomId, b.ShooterId, 50);
                 }
 
                 _bullets.Despawn(roomCode, bulletId);
@@ -121,15 +133,40 @@ public class BulletSimulationService : BackgroundService
                 _ = _hub.Clients.Group(roomCode).SendAsync("playerLifeLost",
                     new PlayerLifeLostDto(hitPlayerId, l, l == 0));
 
+                var scores = GetScoreDict(snap.RoomId);
+                var sc = scores.TryGetValue(b.ShooterId, out var prevScore) ? prevScore : 0;
+                if (l == 0)
+                {
+                    sc += 150;
+                    scores[b.ShooterId] = sc;
+                    _ = _hub.Clients.Group(roomCode).SendAsync("playerScored",
+                        new PlayerScoredDto(b.ShooterId, sc));
+                    _ = _game.RegisterKill(snap.RoomId, b.ShooterId, hitPlayerId, 150);
+                }
+
                 _bullets.Despawn(roomCode, bulletId);
                 _ = _hub.Clients.Group(roomCode).SendAsync("bulletDespawned", bulletId, "hit");
 
                 if (l > 0)
                 {
-                    var rx = ts * 2f;
-                    var ry = ts * 2f;
+                    var spawns = _map.GetSpawnPoints(snap.RoomId);
+                    var rnd = new Random();
+                    var spawn = spawns[rnd.Next(spawns.Length)];
+                    _ = _rooms.UpdatePlayerPositionAsync(roomCode, hitPlayerId, spawn.x, spawn.y, 0f);
                     _ = _hub.Clients.Group(roomCode).SendAsync("playerRespawned",
-                        new PlayerRespawnedDto(hitPlayerId, rx, ry));
+                        new PlayerRespawnedDto(hitPlayerId, spawn.x, spawn.y));
+                }
+                else
+                {
+                    var remaining = lives.Values.Count(v => v > 0);
+                    if (remaining <= 1)
+                    {
+                        var winner = scores.OrderByDescending(k => k.Value).FirstOrDefault().Key ?? hitPlayerId;
+                        _ = _game.EndGame(snap.RoomId);
+                        var final = scores.Select(kvp => new PlayerScoreDto(kvp.Key, kvp.Value)).ToList();
+                        _ = _hub.Clients.Group(roomCode).SendAsync("gameEnded",
+                            new GameEndedDto(winner, final));
+                    }
                 }
                 continue;
             }
@@ -167,6 +204,16 @@ public class BulletSimulationService : BackgroundService
         {
             d = new Dictionary<string, int>();
             _lives[roomId] = d;
+        }
+        return d;
+    }
+
+    private Dictionary<string, int> GetScoreDict(string roomId)
+    {
+        if (!_scores.TryGetValue(roomId, out var d))
+        {
+            d = new Dictionary<string, int>();
+            _scores[roomId] = d;
         }
         return d;
     }

--- a/backend/BattleTanks-Backend/Infrastructure/Background/BulletSimulationService.cs
+++ b/backend/BattleTanks-Backend/Infrastructure/Background/BulletSimulationService.cs
@@ -3,13 +3,14 @@ using Application.DTOs;
 using Application.Interfaces;
 using Infrastructure.SignalR.Abstractions;
 using Infrastructure.SignalR.Hubs;
+using Infrastructure.Interfaces;
 using Microsoft.AspNetCore.SignalR;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 
 namespace Infrastructure.Background;
 
-public class BulletSimulationService : BackgroundService
+public class BulletSimulationService : BackgroundService, ILifeService
 {
     private readonly ILogger<BulletSimulationService> _log;
     private readonly IBulletService _bullets;
@@ -196,6 +197,21 @@ public class BulletSimulationService : BackgroundService
                 return p.PlayerId;
         }
         return null;
+    }
+
+    public int AddLife(string roomId, string playerId, int amount = 1)
+    {
+        var lives = GetLivesDict(roomId);
+        var current = lives.TryGetValue(playerId, out var prev) ? prev : 3;
+        current += amount;
+        lives[playerId] = current;
+        return current;
+    }
+
+    public int GetLives(string roomId, string playerId)
+    {
+        var lives = GetLivesDict(roomId);
+        return lives.TryGetValue(playerId, out var l) ? l : 3;
     }
 
     private Dictionary<string, int> GetLivesDict(string roomId)

--- a/backend/BattleTanks-Backend/Infrastructure/Extensions/ServiceCollectionExtensions.cs
+++ b/backend/BattleTanks-Backend/Infrastructure/Extensions/ServiceCollectionExtensions.cs
@@ -48,7 +48,9 @@ public static class ServiceCollectionExtensions
         services.AddSingleton<IBulletService, InMemoryBulletService>();
         services.AddSingleton<IMqttService, MqttService>();
         services.AddSingleton<IPowerUpService, InMemoryPowerUpService>();
-        services.AddHostedService<BulletSimulationService>();
+        services.AddSingleton<BulletSimulationService>();
+        services.AddSingleton<ILifeService>(sp => sp.GetRequiredService<BulletSimulationService>());
+        services.AddHostedService(sp => sp.GetRequiredService<BulletSimulationService>());
         
         return services;
     }

--- a/backend/BattleTanks-Backend/Infrastructure/Extensions/ServiceCollectionExtensions.cs
+++ b/backend/BattleTanks-Backend/Infrastructure/Extensions/ServiceCollectionExtensions.cs
@@ -45,8 +45,10 @@ public static class ServiceCollectionExtensions
         services.AddSingleton<IGameNotificationService, NoOpNotificationService>();
 
         services.AddSingleton<IMapService, InMemoryMapService>();
-        services.AddSingleton<IBulletService, InMemoryBulletService>(); 
-        services.AddHostedService<BulletSimulationService>();      
+        services.AddSingleton<IBulletService, InMemoryBulletService>();
+        services.AddSingleton<IMqttService, MqttService>();
+        services.AddSingleton<IPowerUpService, InMemoryPowerUpService>();
+        services.AddHostedService<BulletSimulationService>();
         
         return services;
     }

--- a/backend/BattleTanks-Backend/Infrastructure/Infrastructure.csproj
+++ b/backend/BattleTanks-Backend/Infrastructure/Infrastructure.csproj
@@ -22,6 +22,7 @@
     </PackageReference>
     <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="8.0.8" />
     <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="8.13.0" />
+    <PackageReference Include="MQTTnet" Version="4.3.6" />
   </ItemGroup>
 
 </Project>

--- a/backend/BattleTanks-Backend/Infrastructure/Interfaces/ILifeService.cs
+++ b/backend/BattleTanks-Backend/Infrastructure/Interfaces/ILifeService.cs
@@ -1,0 +1,10 @@
+using System;
+
+namespace Infrastructure.Interfaces;
+
+public interface ILifeService
+{
+    int AddLife(string roomId, string playerId, int amount = 1);
+    int GetLives(string roomId, string playerId);
+}
+

--- a/backend/BattleTanks-Backend/Infrastructure/Interfaces/IMqttService.cs
+++ b/backend/BattleTanks-Backend/Infrastructure/Interfaces/IMqttService.cs
@@ -1,0 +1,8 @@
+using System.Threading.Tasks;
+
+namespace Infrastructure.Interfaces;
+
+public interface IMqttService
+{
+    Task PublishAsync(string topic, string payload);
+}

--- a/backend/BattleTanks-Backend/Infrastructure/SignalR/Abstractions/IRoomRegistry.cs
+++ b/backend/BattleTanks-Backend/Infrastructure/SignalR/Abstractions/IRoomRegistry.cs
@@ -20,4 +20,6 @@ public interface IRoomRegistry
     Task JoinAsync(string roomCode, string userId, string username, string connectionId);
     Task<(string? roomCode, string? userId)> LeaveByConnectionAsync(string connectionId);
     Task<IReadOnlyCollection<PlayerStateDto>> GetPlayersByIdAsync(string roomId);
+    Task UpdatePlayerPositionAsync(string roomCode, string userId, float x, float y, float rotation);
+    Task<PlayerStateDto?> AddHealthAsync(string roomCode, string userId, int amount);
 }

--- a/backend/BattleTanks-Backend/Infrastructure/SignalR/Services/InMemoryMapService.cs
+++ b/backend/BattleTanks-Backend/Infrastructure/SignalR/Services/InMemoryMapService.cs
@@ -95,6 +95,19 @@ public class InMemoryMapService : IMapService
         return true;
     }
 
+    public (float x, float y)[] GetSpawnPoints(string roomId)
+    {
+        var (w, h) = GetSize(roomId);
+        var ts = TileSize;
+        return new (float, float)[]
+        {
+            (ts * 2f, ts * 2f),
+            (ts * (w - 3), ts * 2f),
+            (ts * 2f, ts * (h - 3)),
+            (ts * (w - 3), ts * (h - 3))
+        };
+    }
+
     private MapSnapshotDto GenerateDefault(string roomId)
     {
         var tiles = new List<MapTileDto>();
@@ -110,11 +123,21 @@ public class InMemoryMapService : IMapService
             tiles.Add(new MapTileDto(_defaultWidthTiles - 1, y, MapTileType.WallIndestructible, 0));
         }
         
-        var midY = _defaultHeightTiles / 2;
-        for (int x = 3; x < _defaultWidthTiles - 3; x += 4)
+        for (int x = 2; x < _defaultWidthTiles - 2; x += 2)
         {
-            tiles.Add(new MapTileDto(x, midY, MapTileType.WallDestructible, 2));
+            for (int y = 2; y < _defaultHeightTiles - 2; y += 2)
+            {
+                tiles.Add(new MapTileDto(x, y, MapTileType.WallDestructible, 2));
+            }
         }
+
+        var centerX = _defaultWidthTiles / 2;
+        var centerY = _defaultHeightTiles / 2;
+        tiles.Add(new MapTileDto(centerX, centerY, MapTileType.WallIndestructible, 0));
+        tiles.Add(new MapTileDto(centerX - 1, centerY, MapTileType.WallIndestructible, 0));
+        tiles.Add(new MapTileDto(centerX + 1, centerY, MapTileType.WallIndestructible, 0));
+        tiles.Add(new MapTileDto(centerX, centerY - 1, MapTileType.WallIndestructible, 0));
+        tiles.Add(new MapTileDto(centerX, centerY + 1, MapTileType.WallIndestructible, 0));
 
         return new MapSnapshotDto(roomId, _defaultWidthTiles, _defaultHeightTiles, _defaultTileSize, tiles);
     }

--- a/backend/BattleTanks-Backend/Infrastructure/SignalR/Services/InMemoryPowerUpService.cs
+++ b/backend/BattleTanks-Backend/Infrastructure/SignalR/Services/InMemoryPowerUpService.cs
@@ -1,0 +1,76 @@
+using System;
+using System.Collections.Concurrent;
+using System.Linq;
+using System.Text.Json;
+using Application.DTOs;
+using Application.Interfaces;
+using Infrastructure.Interfaces;
+
+namespace Infrastructure.SignalR.Services;
+
+public class InMemoryPowerUpService : IPowerUpService
+{
+    private readonly IMapService _map;
+    private readonly IMqttService _mqtt;
+    private readonly ConcurrentDictionary<string, ConcurrentDictionary<string, PowerUpDto>> _byRoom = new();
+    private readonly Random _rand = new();
+
+    public InMemoryPowerUpService(IMapService map, IMqttService mqtt)
+    {
+        _map = map;
+        _mqtt = mqtt;
+    }
+
+    public PowerUpDto SpawnRandom(string roomCode, string roomId)
+    {
+        var (width, height) = _map.GetSize(roomId);
+        var tileSize = _map.TileSize;
+        int tx, ty;
+        do
+        {
+            tx = _rand.Next(width);
+            ty = _rand.Next(height);
+        } while (_map.IsSolid(roomId, tx, ty));
+
+        var powerUp = new PowerUpDto(
+            Guid.NewGuid().ToString(),
+            roomId,
+            PowerUpType.ExtraLife,
+            (tx + 0.5f) * tileSize,
+            (ty + 0.5f) * tileSize
+        );
+
+        var room = _byRoom.GetOrAdd(roomCode, _ => new ConcurrentDictionary<string, PowerUpDto>());
+        room[powerUp.Id] = powerUp;
+
+        _ = _mqtt.PublishAsync("powerups/spawned", JsonSerializer.Serialize(powerUp));
+
+        return powerUp;
+    }
+
+    public IReadOnlyCollection<PowerUpDto> GetActive(string roomCode)
+    {
+        return _byRoom.TryGetValue(roomCode, out var room)
+            ? room.Values.ToArray()
+            : Array.Empty<PowerUpDto>();
+    }
+
+    public bool TryConsume(string roomCode, string userId, float x, float y, out PowerUpDto? powerUp)
+    {
+        powerUp = null;
+        if (!_byRoom.TryGetValue(roomCode, out var room)) return false;
+        var tileSize = _map.TileSize;
+        foreach (var kvp in room)
+        {
+            var p = kvp.Value;
+            if (Math.Abs(p.X - x) <= tileSize / 2f && Math.Abs(p.Y - y) <= tileSize / 2f)
+            {
+                room.TryRemove(kvp.Key, out _);
+                powerUp = p;
+                _ = _mqtt.PublishAsync("powerups/consumed", JsonSerializer.Serialize(new { roomCode, userId, powerUpId = p.Id }));
+                return true;
+            }
+        }
+        return false;
+    }
+}

--- a/backend/BattleTanks-Backend/Infrastructure/SignalR/Services/InMemoryRoomRegistry.cs
+++ b/backend/BattleTanks-Backend/Infrastructure/SignalR/Services/InMemoryRoomRegistry.cs
@@ -80,6 +80,31 @@ internal sealed class InMemoryRoomRegistry : IRoomRegistry
         return Task.FromResult<IReadOnlyCollection<PlayerStateDto>>(Array.Empty<PlayerStateDto>());
     }
 
+    public Task UpdatePlayerPositionAsync(string roomCode, string userId, float x, float y, float rotation)
+    {
+        if (_codeToId.TryGetValue(roomCode, out var roomId) &&
+            _byId.TryGetValue(roomId, out var room) &&
+            room.Players.TryGetValue(userId, out var state))
+        {
+            var newState = state with { X = x, Y = y, Rotation = rotation };
+            room.Players[userId] = newState;
+        }
+        return Task.CompletedTask;
+    }
+
+    public Task<PlayerStateDto?> AddHealthAsync(string roomCode, string userId, int amount)
+    {
+        if (_codeToId.TryGetValue(roomCode, out var roomId) &&
+            _byId.TryGetValue(roomId, out var room) &&
+            room.Players.TryGetValue(userId, out var state))
+        {
+            var newState = state with { Health = state.Health + amount };
+            room.Players[userId] = newState;
+            return Task.FromResult<PlayerStateDto?>(newState);
+        }
+        return Task.FromResult<PlayerStateDto?>(null);
+    }
+
     private async Task<Room> EnsureRoomByCodeAsync(string roomCode)
     {
         if (_codeToId.TryGetValue(roomCode, out var id) && _byId.TryGetValue(id, out var cached))

--- a/backend/BattleTanks-Backend/Infrastructure/services/MqttService.cs
+++ b/backend/BattleTanks-Backend/Infrastructure/services/MqttService.cs
@@ -1,0 +1,53 @@
+using System.Threading.Tasks;
+using Infrastructure.Interfaces;
+using Microsoft.Extensions.Configuration;
+using MQTTnet;
+using MQTTnet.Client;
+
+namespace Infrastructure.Services;
+
+public class MqttService : IMqttService, IAsyncDisposable
+{
+    private readonly IMqttClient _client;
+    private readonly MqttClientOptions _options;
+    private readonly string _prefix;
+
+    public MqttService(IConfiguration configuration)
+    {
+        var factory = new MqttFactory();
+        _client = factory.CreateMqttClient();
+
+        var host = configuration.GetValue<string>("MqttSettings:Host") ?? "localhost";
+        var port = configuration.GetValue<int>("MqttSettings:Port", 1883);
+        _prefix = configuration.GetValue<string>("MqttSettings:TopicPrefix") ?? "battletanks";
+
+        _options = new MqttClientOptionsBuilder()
+            .WithTcpServer(host, port)
+            .Build();
+    }
+
+    private async Task EnsureConnectedAsync()
+    {
+        if (!_client.IsConnected)
+        {
+            await _client.ConnectAsync(_options);
+        }
+    }
+
+    public async Task PublishAsync(string topic, string payload)
+    {
+        await EnsureConnectedAsync();
+        var message = new MqttApplicationMessageBuilder()
+            .WithTopic($"{_prefix}/{topic}")
+            .WithPayload(payload)
+            .Build();
+        await _client.PublishAsync(message);
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        if (_client.IsConnected)
+            await _client.DisconnectAsync();
+        _client.Dispose();
+    }
+}

--- a/frontend/BattleTanks-Frontend/src/app/core/models/game.models.ts
+++ b/frontend/BattleTanks-Frontend/src/app/core/models/game.models.ts
@@ -6,6 +6,8 @@ export interface PlayerStateDto {
   rotation: number;
   health: number;
   isAlive: boolean;
+  lives?: number;
+  score?: number;
 }
 
 export interface PlayerPositionDto {
@@ -66,6 +68,16 @@ export interface PlayerRespawnedDto {
   playerId: string;
   x: number;
   y: number;
+}
+
+export interface PlayerScoredDto {
+  playerId: string;
+  score: number;
+}
+
+export interface GameEndedDto {
+  winnerPlayerId: string;
+  scores: PlayerScoredDto[];
 }
 
 export interface RoomSnapshotDto {

--- a/frontend/BattleTanks-Frontend/src/app/core/models/game.models.ts
+++ b/frontend/BattleTanks-Frontend/src/app/core/models/game.models.ts
@@ -85,3 +85,13 @@ export interface RoomSnapshotDto {
   roomCode: string;
   players: PlayerStateDto[];
 }
+
+export type PowerUpType = 'ExtraLife';
+
+export interface PowerUpDto {
+  id: string;
+  roomId: string;
+  type: PowerUpType;
+  x: number;
+  y: number;
+}

--- a/frontend/BattleTanks-Frontend/src/app/core/services/room.service.ts
+++ b/frontend/BattleTanks-Frontend/src/app/core/services/room.service.ts
@@ -20,4 +20,8 @@ export class RoomService {
   getRoom(roomId: string) {
     return this.http.get<RoomStateDto>(`${this.base}/Rooms/${roomId}`);
   }
+
+  startGame(roomId: string) {
+    return this.http.post<RoomStateDto>(`${this.base}/Rooms/${roomId}/start`, {});
+  }
 }

--- a/frontend/BattleTanks-Frontend/src/app/core/services/signalr.service.ts
+++ b/frontend/BattleTanks-Frontend/src/app/core/services/signalr.service.ts
@@ -11,6 +11,8 @@ import {
   MapTileDto,
   PlayerLifeLostDto,
   PlayerRespawnedDto,
+  PlayerScoredDto,
+  GameEndedDto,
   RoomSnapshotDto,
 } from '../models/game.models';
 
@@ -30,6 +32,8 @@ export class SignalRService {
   readonly mapTileUpdated$ = new Subject<MapTileDto>();
   readonly playerLifeLost$ = new Subject<PlayerLifeLostDto>();
   readonly playerRespawned$ = new Subject<PlayerRespawnedDto>();
+  readonly playerScored$ = new Subject<PlayerScoredDto>();
+  readonly gameEnded$ = new Subject<GameEndedDto>();
 
   readonly reconnected$ = new Subject<void>();
   readonly disconnected$ = new Subject<void>();
@@ -62,6 +66,8 @@ export class SignalRService {
     this.hub.on('mapTileUpdated', (tile: MapTileDto) => this.mapTileUpdated$.next(tile));
     this.hub.on('playerLifeLost', (data: PlayerLifeLostDto) => this.playerLifeLost$.next(data));
     this.hub.on('playerRespawned', (data: PlayerRespawnedDto) => this.playerRespawned$.next(data));
+    this.hub.on('playerScored', (data: PlayerScoredDto) => this.playerScored$.next(data));
+    this.hub.on('gameEnded', (data: GameEndedDto) => this.gameEnded$.next(data));
 
     this.hub.onreconnected(() => this.reconnected$.next());
     this.hub.onclose(() => this.disconnected$.next());

--- a/frontend/BattleTanks-Frontend/src/app/core/services/signalr.service.ts
+++ b/frontend/BattleTanks-Frontend/src/app/core/services/signalr.service.ts
@@ -14,6 +14,7 @@ import {
   PlayerScoredDto,
   GameEndedDto,
   RoomSnapshotDto,
+  PowerUpDto,
 } from '../models/game.models';
 
 @Injectable({ providedIn: 'root' })
@@ -34,6 +35,9 @@ export class SignalRService {
   readonly playerRespawned$ = new Subject<PlayerRespawnedDto>();
   readonly playerScored$ = new Subject<PlayerScoredDto>();
   readonly gameEnded$ = new Subject<GameEndedDto>();
+  readonly powerUpsSnapshot$ = new Subject<PowerUpDto[]>();
+  readonly powerUpSpawned$ = new Subject<PowerUpDto>();
+  readonly powerUpCollected$ = new Subject<{ powerUpId: string; userId: string }>();
 
   readonly reconnected$ = new Subject<void>();
   readonly disconnected$ = new Subject<void>();
@@ -68,6 +72,9 @@ export class SignalRService {
     this.hub.on('playerRespawned', (data: PlayerRespawnedDto) => this.playerRespawned$.next(data));
     this.hub.on('playerScored', (data: PlayerScoredDto) => this.playerScored$.next(data));
     this.hub.on('gameEnded', (data: GameEndedDto) => this.gameEnded$.next(data));
+    this.hub.on('powerUpsSnapshot', (list: PowerUpDto[]) => this.powerUpsSnapshot$.next(list));
+    this.hub.on('powerUpSpawned', (p: PowerUpDto) => this.powerUpSpawned$.next(p));
+    this.hub.on('powerUpCollected', (payload: { powerUpId: string; userId: string }) => this.powerUpCollected$.next(payload));
 
     this.hub.onreconnected(() => this.reconnected$.next());
     this.hub.onclose(() => this.disconnected$.next());

--- a/frontend/BattleTanks-Frontend/src/app/features/room/room-canvas/room-canvas.component.ts
+++ b/frontend/BattleTanks-Frontend/src/app/features/room/room-canvas/room-canvas.component.ts
@@ -87,17 +87,12 @@ export class RoomCanvasComponent implements AfterViewInit, OnDestroy {
 
     effect(() => {
       const ms = this.mapSize();
-      if (!this.spawnPlaced && ms.width > 0 && ms.height > 0) {
-        const centerX = (ms.width * ms.tileSize) / 2;
-        const centerY = (ms.height * ms.tileSize) / 2;
-        this.setPlayerPositionClamped(centerX, centerY);
-        this.rot.set(0);
+      const meId = this.me()?.id;
+      const mePlayer = this.players().find(p => p.playerId === meId);
+      if (!this.spawnPlaced && ms.width > 0 && ms.height > 0 && mePlayer) {
+        this.setPlayerPositionClamped(mePlayer.x, mePlayer.y);
+        this.rot.set(mePlayer.rotation || 0);
         this.spawnPlaced = true;
-
-        const meId = this.me()?.id ?? 'me';
-        this.store.dispatch(roomActions.updatePosition({
-          dto: { playerId: meId, x: this.px(), y: this.py(), rotation: this.rot(), timestamp: Date.now() }
-        }));
       }
     });
   }

--- a/frontend/BattleTanks-Frontend/src/app/features/room/room-canvas/room-canvas.component.ts
+++ b/frontend/BattleTanks-Frontend/src/app/features/room/room-canvas/room-canvas.component.ts
@@ -13,7 +13,7 @@ import {
 import { CommonModule } from '@angular/common';
 import { Store } from '@ngrx/store';
 import { toSignal } from '@angular/core/rxjs-interop';
-import { selectBullets, selectPlayers, selectMapSize, selectTilesByKey } from '../store/room.selectors';
+import { selectBullets, selectPlayers, selectMapSize, selectTilesByKey, selectPowerUps } from '../store/room.selectors';
 import { selectUser } from '../../auth/store/auth.selectors';
 import { roomActions } from '../store/room.actions';
 
@@ -44,6 +44,7 @@ export class RoomCanvasComponent implements AfterViewInit, OnDestroy {
 
   players      = toSignal(this.store.select(selectPlayers), { initialValue: [] });
   serverBullets = toSignal(this.store.select(selectBullets), { initialValue: [] });
+  powerUps     = toSignal(this.store.select(selectPowerUps), { initialValue: [] });
   me           = toSignal(this.store.select(selectUser), { initialValue: null });
 
   mapSize   = toSignal(this.store.select(selectMapSize), { initialValue: { width: 0, height: 0, tileSize: 40 } });
@@ -154,7 +155,10 @@ export class RoomCanvasComponent implements AfterViewInit, OnDestroy {
     const maxY = Math.floor((cy + this.halfH - 1) / tileSize);
     for (let ty = minY; ty <= maxY; ty++) {
       for (let tx = minX; tx <= maxX; tx++) {
-        if (this.isSolidTile(tx, ty)) return true;
+        if (this.isSolidTile(tx, ty)) {
+          console.log('Collision with tile', tx, ty, 'type', this.tilesByKey()[`${tx},${ty}`]?.type ?? 'boundary');
+          return true;
+        }
       }
     }
     return false;
@@ -250,6 +254,19 @@ export class RoomCanvasComponent implements AfterViewInit, OnDestroy {
         const w = Math.max(4, (tileSize - 8) * (hp / 2));
         ctx.fillRect(x + 4, y + tileSize - 8, w, 4);
       }
+    });
+
+    // Power-ups
+    this.powerUps().forEach(p => {
+      const x = p.x, y = p.y;
+      ctx.fillStyle = '#f87171';
+      ctx.beginPath();
+      ctx.moveTo(x, y + 5);
+      ctx.arc(x - 4, y - 2, 4, Math.PI, 0, true);
+      ctx.arc(x + 4, y - 2, 4, Math.PI, 0, true);
+      ctx.lineTo(x, y + 5);
+      ctx.closePath();
+      ctx.fill();
     });
 
     this.cosmetics.forEach(b => {

--- a/frontend/BattleTanks-Frontend/src/app/features/room/room.component.html
+++ b/frontend/BattleTanks-Frontend/src/app/features/room/room.component.html
@@ -2,7 +2,10 @@
   <div class="w-full max-w-6xl pixel-card p-4 relative">
     <div class="flex items-center justify-between mb-4">
       <h1 class="pixel-title">BATTLE TANKS · SALA</h1>
-      <a routerLink="/lobby" class="text-emerald-200 underline text-xs">Volver al lobby</a>
+      <div class="space-x-2 flex items-center">
+        <button (click)="startGame()" class="text-xs px-2 py-1 bg-emerald-700 text-white rounded">Start Game</button>
+        <a routerLink="/lobby" class="text-emerald-200 underline text-xs">Volver al lobby</a>
+      </div>
     </div>
 
     @if (error(); as err) {

--- a/frontend/BattleTanks-Frontend/src/app/features/room/room.component.html
+++ b/frontend/BattleTanks-Frontend/src/app/features/room/room.component.html
@@ -21,6 +21,15 @@
           <app-room-canvas />
         </div>
         <div>
+          <div class="mb-4 bg-emerald-800/30 p-2 rounded text-emerald-100">
+            <h2 class="text-xs font-bold mb-2">Jugadores</h2>
+            @for (p of players(); track p.playerId) {
+              <div class="text-xs flex justify-between">
+                <span>{{ p.username }}</span>
+                <span>❤️ {{ p.lives ?? 3 }} · ⭐ {{ p.score ?? 0 }}</span>
+              </div>
+            }
+          </div>
           <app-chat-panel />
         </div>
       </div>

--- a/frontend/BattleTanks-Frontend/src/app/features/room/room.component.ts
+++ b/frontend/BattleTanks-Frontend/src/app/features/room/room.component.ts
@@ -5,10 +5,11 @@ import { Store } from '@ngrx/store';
 import { toSignal } from '@angular/core/rxjs-interop';
 
 import { roomActions } from './store/room.actions';
-import { selectHubConnected, selectJoined, selectRoomError } from './store/room.selectors';
+import { selectHubConnected, selectJoined, selectRoomError, selectRoomId } from './store/room.selectors';
 import { selectUser } from './../auth/store/auth.selectors';
 import { RoomCanvasComponent } from './room-canvas/room-canvas.component';
 import { ChatPanelComponent } from './chat-panel/chat-panel.component';
+import { RoomService } from '../../core/services/room.service';
 
 @Component({
   standalone: true,
@@ -21,11 +22,13 @@ import { ChatPanelComponent } from './chat-panel/chat-panel.component';
 export class RoomComponent implements OnInit, OnDestroy {
   private route = inject(ActivatedRoute);
   private store = inject(Store);
+  private roomsHttp = inject(RoomService);
 
   hubConnected = toSignal(this.store.select(selectHubConnected), { initialValue: false });
   joined       = toSignal(this.store.select(selectJoined),       { initialValue: false });
   error        = toSignal(this.store.select(selectRoomError),    { initialValue: null });
   user         = toSignal(this.store.select(selectUser),         { initialValue: null });
+  roomId       = toSignal(this.store.select(selectRoomId),       { initialValue: null });
 
   private roomCode = signal<string | null>(null);
 
@@ -49,5 +52,12 @@ export class RoomComponent implements OnInit, OnDestroy {
 
   ngOnDestroy(): void {
     this.store.dispatch(roomActions.leaveRoom());
+  }
+
+  startGame() {
+    const id = this.roomId();
+    if (id) {
+      this.roomsHttp.startGame(id).subscribe();
+    }
   }
 }

--- a/frontend/BattleTanks-Frontend/src/app/features/room/room.component.ts
+++ b/frontend/BattleTanks-Frontend/src/app/features/room/room.component.ts
@@ -5,7 +5,7 @@ import { Store } from '@ngrx/store';
 import { toSignal } from '@angular/core/rxjs-interop';
 
 import { roomActions } from './store/room.actions';
-import { selectHubConnected, selectJoined, selectRoomError, selectRoomId } from './store/room.selectors';
+import { selectHubConnected, selectJoined, selectRoomError, selectRoomId, selectPlayers } from './store/room.selectors';
 import { selectUser } from './../auth/store/auth.selectors';
 import { RoomCanvasComponent } from './room-canvas/room-canvas.component';
 import { ChatPanelComponent } from './chat-panel/chat-panel.component';
@@ -29,6 +29,7 @@ export class RoomComponent implements OnInit, OnDestroy {
   error        = toSignal(this.store.select(selectRoomError),    { initialValue: null });
   user         = toSignal(this.store.select(selectUser),         { initialValue: null });
   roomId       = toSignal(this.store.select(selectRoomId),       { initialValue: null });
+  players      = toSignal(this.store.select(selectPlayers),      { initialValue: [] });
 
   private roomCode = signal<string | null>(null);
 

--- a/frontend/BattleTanks-Frontend/src/app/features/room/store/room.actions.ts
+++ b/frontend/BattleTanks-Frontend/src/app/features/room/store/room.actions.ts
@@ -11,6 +11,7 @@ import {
   PlayerScoredDto,
   GameEndedDto,
   RoomSnapshotDto,
+  PowerUpDto,
 } from '../../../core/models/game.models';
 
 export const roomActions = createActionGroup({
@@ -40,11 +41,14 @@ export const roomActions = createActionGroup({
     'Player Left': props<{ userId: string }>(),
     'Player Moved': props<{ player: PlayerStateDto | { playerId: string; x: number; y: number; rotation: number; health?: number; isAlive?: boolean; username?: string } }>(),
     'Bullet Spawned': props<{ bullet: BulletStateDto }>(),
-    'Bullet Despawned': props<{ bulletId: string }>(),
+    'Bullet Despawned': props<{ bulletId: string; reason?: string }>(),
     'Player Life Lost': props<{ data: PlayerLifeLostDto }>(),
     'Player Respawned': props<{ data: PlayerRespawnedDto }>(),
     'Player Scored': props<{ data: PlayerScoredDto }>(),
     'Game Ended': props<{ data: GameEndedDto }>(),
+    'PowerUps Snapshot Received': props<{ powerUps: PowerUpDto[] }>(),
+    'PowerUp Spawned': props<{ powerUp: PowerUpDto }>(),
+    'PowerUp Collected': props<{ powerUpId: string; userId: string }>(),
     'Message Received': props<{ msg: ChatMessageDto }>(),
 
     // Cliente→servidor

--- a/frontend/BattleTanks-Frontend/src/app/features/room/store/room.actions.ts
+++ b/frontend/BattleTanks-Frontend/src/app/features/room/store/room.actions.ts
@@ -8,6 +8,8 @@ import {
   MapTileDto,
   PlayerLifeLostDto,
   PlayerRespawnedDto,
+  PlayerScoredDto,
+  GameEndedDto,
   RoomSnapshotDto,
 } from '../../../core/models/game.models';
 
@@ -27,7 +29,7 @@ export const roomActions = createActionGroup({
     'Leave Room': emptyProps(),
     'Left': emptyProps(),
 
-    'Roster Loaded': props<{ players: PlayerStateDto[] }>(),
+    'Roster Loaded': props<{ players: PlayerStateDto[]; roomId: string | null }>(),
 
     // Snapshots nuevos
     'Room Snapshot Received': props<{ snapshot: RoomSnapshotDto }>(),
@@ -41,6 +43,8 @@ export const roomActions = createActionGroup({
     'Bullet Despawned': props<{ bulletId: string }>(),
     'Player Life Lost': props<{ data: PlayerLifeLostDto }>(),
     'Player Respawned': props<{ data: PlayerRespawnedDto }>(),
+    'Player Scored': props<{ data: PlayerScoredDto }>(),
+    'Game Ended': props<{ data: GameEndedDto }>(),
     'Message Received': props<{ msg: ChatMessageDto }>(),
 
     // Cliente→servidor

--- a/frontend/BattleTanks-Frontend/src/app/features/room/store/room.effects.spec.ts
+++ b/frontend/BattleTanks-Frontend/src/app/features/room/store/room.effects.spec.ts
@@ -18,6 +18,9 @@ class SignalRServiceMock {
   playerMoved$ = new Subject<any>();
   bulletSpawned$ = new Subject<any>();
   bulletDespawned$ = new Subject<{ bulletId: string; reason: string }>();
+  powerUpsSnapshot$ = new Subject<any>();
+  powerUpSpawned$ = new Subject<any>();
+  powerUpCollected$ = new Subject<any>();
   reconnected$ = new Subject<void>();
   disconnected$ = new Subject<void>();
 

--- a/frontend/BattleTanks-Frontend/src/app/features/room/store/room.effects.ts
+++ b/frontend/BattleTanks-Frontend/src/app/features/room/store/room.effects.ts
@@ -39,7 +39,7 @@ export class RoomEffects {
           this.hub.chatMessage$.pipe(map((msg) => roomActions.messageReceived({ msg }))),
           this.hub.playerMoved$.pipe(map((player: any) => roomActions.playerMoved({ player }))),
           this.hub.bulletSpawned$.pipe(map((bullet) => roomActions.bulletSpawned({ bullet }))),
-          this.hub.bulletDespawned$.pipe(map(({ bulletId }) => roomActions.bulletDespawned({ bulletId }))),
+          this.hub.bulletDespawned$.pipe(map(({ bulletId, reason }) => roomActions.bulletDespawned({ bulletId, reason }))),
 
           this.hub.roomSnapshot$.pipe(map((snapshot) => roomActions.roomSnapshotReceived({ snapshot }))),
           this.hub.mapSnapshot$.pipe(map((snapshot) => roomActions.mapSnapshotReceived({ snapshot }))),
@@ -48,6 +48,9 @@ export class RoomEffects {
           this.hub.playerRespawned$.pipe(map((data) => roomActions.playerRespawned({ data }))),
           this.hub.playerScored$.pipe(map((data) => roomActions.playerScored({ data }))),
           this.hub.gameEnded$.pipe(map((data) => roomActions.gameEnded({ data }))),
+          this.hub.powerUpsSnapshot$.pipe(map((powerUps) => roomActions.powerUpsSnapshotReceived({ powerUps }))),
+          this.hub.powerUpSpawned$.pipe(map((powerUp) => roomActions.powerUpSpawned({ powerUp }))),
+          this.hub.powerUpCollected$.pipe(map((payload) => roomActions.powerUpCollected(payload))),
         ).pipe(takeUntil(stop$));
       })
     )
@@ -136,5 +139,14 @@ export class RoomEffects {
         )
       )
     )
+  );
+
+  logBulletCollisions$ = createEffect(
+    () =>
+      this.actions$.pipe(
+        ofType(roomActions.bulletDespawned),
+        tap(({ bulletId, reason }) => console.log('Bullet', bulletId, 'despawned because', reason))
+      ),
+    { dispatch: false }
   );
 }

--- a/frontend/BattleTanks-Frontend/src/app/features/room/store/room.effects.ts
+++ b/frontend/BattleTanks-Frontend/src/app/features/room/store/room.effects.ts
@@ -46,6 +46,8 @@ export class RoomEffects {
           this.hub.mapTileUpdated$.pipe(map((tile) => roomActions.mapTileUpdated({ tile }))),
           this.hub.playerLifeLost$.pipe(map((data) => roomActions.playerLifeLost({ data }))),
           this.hub.playerRespawned$.pipe(map((data) => roomActions.playerRespawned({ data }))),
+          this.hub.playerScored$.pipe(map((data) => roomActions.playerScored({ data }))),
+          this.hub.gameEnded$.pipe(map((data) => roomActions.gameEnded({ data }))),
         ).pipe(takeUntil(stop$));
       })
     )
@@ -128,9 +130,9 @@ export class RoomEffects {
             const match = list.find(r => r.roomCode === code);
             return match?.roomId ?? null;
           }),
-          switchMap((roomId) => roomId ? this.roomsHttp.getRoom(roomId) : of(null)),
-          map((room) => roomActions.rosterLoaded({ players: room?.players ?? [] })),
-          catchError(() => of(roomActions.rosterLoaded({ players: [] })))
+          switchMap((roomId) => roomId ? this.roomsHttp.getRoom(roomId).pipe(map(r => ({ room: r, roomId }))) : of({ room: null, roomId: null })),
+          map(({ room, roomId }) => roomActions.rosterLoaded({ players: room?.players ?? [], roomId })),
+          catchError(() => of(roomActions.rosterLoaded({ players: [], roomId: null })))
         )
       )
     )

--- a/frontend/BattleTanks-Frontend/src/app/features/room/store/room.reducer.spec.ts
+++ b/frontend/BattleTanks-Frontend/src/app/features/room/store/room.reducer.spec.ts
@@ -1,4 +1,4 @@
-import { roomReducer, RoomState, roomPlayersAdapter, roomBulletsAdapter } from './room.reducer';
+import { roomReducer, RoomState, roomPlayersAdapter, roomBulletsAdapter, roomPowerUpsAdapter } from './room.reducer';
 import { roomActions } from './room.actions';
 import { ChatMessageDto } from '../../../core/models/game.models';
 
@@ -14,6 +14,7 @@ describe('Room Reducer', () => {
       error: null,
       players: roomPlayersAdapter.getInitialState(),
       bullets: roomBulletsAdapter.getInitialState(),
+      powerUps: roomPowerUpsAdapter.getInitialState(),
       chat: [],
       lastUsername: null,
       map: null,

--- a/frontend/BattleTanks-Frontend/src/app/features/room/store/room.reducer.spec.ts
+++ b/frontend/BattleTanks-Frontend/src/app/features/room/store/room.reducer.spec.ts
@@ -7,6 +7,7 @@ describe('Room Reducer', () => {
 
   beforeEach(() => {
     initial = {
+      roomId: null,
       roomCode: null,
       joined: false,
       hubConnected: false,
@@ -15,6 +16,7 @@ describe('Room Reducer', () => {
       bullets: roomBulletsAdapter.getInitialState(),
       chat: [],
       lastUsername: null,
+      map: null,
     };
   });
 

--- a/frontend/BattleTanks-Frontend/src/app/features/room/store/room.selectors.spec.ts
+++ b/frontend/BattleTanks-Frontend/src/app/features/room/store/room.selectors.spec.ts
@@ -16,6 +16,7 @@ describe('Room Selectors', () => {
     ], roomBulletsAdapter.getInitialState());
 
     const room: RoomState = {
+      roomId: 'r1',
       roomCode: 'ABCD',
       joined: true,
       hubConnected: true,
@@ -24,6 +25,7 @@ describe('Room Selectors', () => {
       bullets,
       chat: [],
       lastUsername: 'juan',
+      map: null,
     };
     state = { room };
   });

--- a/frontend/BattleTanks-Frontend/src/app/features/room/store/room.selectors.spec.ts
+++ b/frontend/BattleTanks-Frontend/src/app/features/room/store/room.selectors.spec.ts
@@ -1,5 +1,5 @@
 import { selectBullets, selectChat, selectHubConnected, selectJoined, selectPlayers, selectRoomCode } from './room.selectors';
-import { RoomState, roomPlayersAdapter, roomBulletsAdapter } from './room.reducer';
+import { RoomState, roomPlayersAdapter, roomBulletsAdapter, roomPowerUpsAdapter } from './room.reducer';
 import { MemoizedSelector } from '@ngrx/store';
 
 describe('Room Selectors', () => {
@@ -15,6 +15,8 @@ describe('Room Selectors', () => {
       { bulletId: 'b1', roomId: 'r1', shooterId: 'p1', x: 10, y: 20, directionRadians: 0, speed: 100, spawnTimestamp: 1, isActive: true },
     ], roomBulletsAdapter.getInitialState());
 
+    const powerUps = roomPowerUpsAdapter.getInitialState();
+
     const room: RoomState = {
       roomId: 'r1',
       roomCode: 'ABCD',
@@ -23,6 +25,7 @@ describe('Room Selectors', () => {
       error: null,
       players,
       bullets,
+      powerUps,
       chat: [],
       lastUsername: 'juan',
       map: null,

--- a/frontend/BattleTanks-Frontend/src/app/features/room/store/room.selectors.ts
+++ b/frontend/BattleTanks-Frontend/src/app/features/room/store/room.selectors.ts
@@ -4,6 +4,7 @@ import { roomBulletsAdapter, roomPlayersAdapter, RoomState } from './room.reduce
 export const selectRoomState = createFeatureSelector<RoomState>('room');
 
 export const selectRoomCode = createSelector(selectRoomState, (s) => s.roomCode);
+export const selectRoomId = createSelector(selectRoomState, (s) => s.roomId);
 export const selectHubConnected = createSelector(selectRoomState, (s) => s.hubConnected);
 export const selectJoined = createSelector(selectRoomState, (s) => s.joined);
 export const selectRoomError = createSelector(selectRoomState, (s) => s.error);

--- a/frontend/BattleTanks-Frontend/src/app/features/room/store/room.selectors.ts
+++ b/frontend/BattleTanks-Frontend/src/app/features/room/store/room.selectors.ts
@@ -1,5 +1,5 @@
 import { createFeatureSelector, createSelector } from '@ngrx/store';
-import { roomBulletsAdapter, roomPlayersAdapter, RoomState } from './room.reducer';
+import { roomBulletsAdapter, roomPlayersAdapter, roomPowerUpsAdapter, RoomState } from './room.reducer';
 
 export const selectRoomState = createFeatureSelector<RoomState>('room');
 
@@ -12,9 +12,11 @@ export const selectChat = createSelector(selectRoomState, (s) => s.chat);
 
 const playersSelectors = roomPlayersAdapter.getSelectors();
 const bulletsSelectors = roomBulletsAdapter.getSelectors();
+const powerUpsSelectors = roomPowerUpsAdapter.getSelectors();
 
 export const selectPlayers = createSelector(selectRoomState, (s) => playersSelectors.selectAll(s.players));
 export const selectBullets = createSelector(selectRoomState, (s) => bulletsSelectors.selectAll(s.bullets));
+export const selectPowerUps = createSelector(selectRoomState, (s) => powerUpsSelectors.selectAll(s.powerUps));
 
 export const selectMap = createSelector(selectRoomState, (s) => s.map);
 export const selectMapSize = createSelector(selectMap, (m) => ({

--- a/infraestructure/docker-compose.yml
+++ b/infraestructure/docker-compose.yml
@@ -83,6 +83,21 @@ services:
     networks:
       - battletanks-network
 
+  # EMQX MQTT broker for additional notifications
+  mqtt:
+    image: emqx/emqx:5.7.0
+    container_name: battletanks-emqx
+    restart: unless-stopped
+    environment:
+      EMQX_AUTH__ENABLE: "false"
+      EMQX_ALLOW_ANONYMOUS: "true"
+    ports:
+      - "1883:1883"
+      - "8083:8083"
+      - "18083:18083"
+    networks:
+      - battletanks-network
+
 volumes:
   postgres_data:
     driver: local


### PR DESCRIPTION
## Summary
- add emqx service to docker compose
- connect backend to mqtt and random power-up spawns
- broadcast power-up pickups and health updates through SignalR

## Testing
- `dotnet test` *(fail: command not found)*
- `apt-get update` *(fail: 403  Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68aa6f88f448832e810ff95ef93d8f3f