### PR TITLE
Integrate NgRx game flow

### DIFF
--- a/frontend/BattleTanks-Frontend/src/app/core/services/room.service.ts
+++ b/frontend/BattleTanks-Frontend/src/app/core/services/room.service.ts
@@ -26,6 +26,10 @@ export class RoomService {
   }
 
   startGame(roomId: string) {
-    return this.http.post<RoomStateDto>(`${this.base}/Rooms/${roomId}/start`, {});
+    return this.http.post<void>(`${this.base}/Rooms/${roomId}/start`, {});
+  }
+
+  endGame(roomId: string) {
+    return this.http.post<void>(`${this.base}/Rooms/${roomId}/end`, {});
   }
 }

--- a/frontend/BattleTanks-Frontend/src/app/features/lobby/rooms-list/rooms-list.component.html
+++ b/frontend/BattleTanks-Frontend/src/app/features/lobby/rooms-list/rooms-list.component.html
@@ -1,22 +1,27 @@
 <div class="pixel-card p-4">
   <div class="flex items-center justify-between mb-3">
     <h2 class="pixel-title text-base">SALAS ACTIVAS</h2>
-    @if (loading()) { <span class="text-xs text-emerald-300">Actualizando...</span> }
+    <div class="flex items-center space-x-2">
+      <button (click)="onLogout()" class="text-xs underline text-emerald-200">Logout</button>
+      @if (loading$ | async) { <span class="text-xs text-emerald-300">Actualizando...</span> }
+    </div>
   </div>
 
-  @if (rooms().length === 0) {
-    <p class="text-emerald-200 text-xs">No hay salas activas aún.</p>
-  } @else {
-    <ul class="divide-y divide-emerald-800/40">
-      @for (room of rooms(); track room.roomId) {
-        <li class="py-3 flex items-center justify-between">
-          <div class="text-emerald-100 text-sm">
-            <div class="font-semibold">Código: <span class="text-emerald-300">{{ room.roomCode }}</span></div>
-            <div class="text-xs opacity-80">Estado: {{ room.status }} · Jugadores: {{ room.players.length }}</div>
-          </div>
-          <button class="pixel-btn px-3 py-2" (click)="enter(room.roomCode)">ENTRAR</button>
-        </li>
-      }
-    </ul>
+  @if (rooms$ | async as rooms) {
+    @if (rooms.length === 0) {
+      <p class="text-emerald-200 text-xs">No hay salas activas aún.</p>
+    } @else {
+      <ul class="divide-y divide-emerald-800/40">
+        @for (room of rooms; track room.roomId) {
+          <li class="py-3 flex items-center justify-between">
+            <div class="text-emerald-100 text-sm">
+              <div class="font-semibold">Código: <span class="text-emerald-300">{{ room.roomCode }}</span></div>
+              <div class="text-xs opacity-80">Estado: {{ room.status }} · Jugadores: {{ room.players.length }}</div>
+            </div>
+            <button class="pixel-btn px-3 py-2" (click)="enter(room.roomCode)">ENTRAR</button>
+          </li>
+        }
+      </ul>
+    }
   }
 </div>

--- a/frontend/BattleTanks-Frontend/src/app/features/lobby/rooms-list/rooms-list.component.ts
+++ b/frontend/BattleTanks-Frontend/src/app/features/lobby/rooms-list/rooms-list.component.ts
@@ -1,9 +1,11 @@
 import { ChangeDetectionStrategy, Component, inject } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { Store } from '@ngrx/store';
-import { toSignal } from '@angular/core/rxjs-interop';
 import { selectRooms, selectRoomsLoading } from '../store/rooms.selectors';
 import { Router } from '@angular/router';
+import { AuthService } from '../../../core/services/auth.service';
+import { authActions } from '../../auth/store/auth.actions';
+import { Observable } from 'rxjs';
 
 @Component({
   standalone: true,
@@ -16,11 +18,18 @@ import { Router } from '@angular/router';
 export class RoomsListComponent {
   private store = inject(Store);
   private router = inject(Router);
+  private auth = inject(AuthService);
 
-  rooms   = toSignal(this.store.select(selectRooms), { initialValue: [] });
-  loading = toSignal(this.store.select(selectRoomsLoading), { initialValue: false });
+  rooms$: Observable<any[]> = this.store.select(selectRooms);
+  loading$: Observable<boolean> = this.store.select(selectRoomsLoading);
 
   enter(code: string) {
     this.router.navigateByUrl(`/rooms/${encodeURIComponent(code)}`);
+  }
+
+  onLogout() {
+    this.auth.logout().subscribe(() => {
+      this.store.dispatch(authActions.logoutSuccess());
+    });
   }
 }

--- a/frontend/BattleTanks-Frontend/src/app/features/room/room.component.html
+++ b/frontend/BattleTanks-Frontend/src/app/features/room/room.component.html
@@ -1,40 +1,44 @@
 <div class="grid min-h-screen px-3 place-items-center grid-bg">
   <div class="relative w-full max-w-6xl p-4 pixel-card">
-    <div class="flex items-center justify-between mb-4">
-      <h1 class="pixel-title">BATTLE TANKS · SALA</h1>
-      <div class="flex items-center space-x-2">
-        <button (click)="startGame()" class="px-2 py-1 text-xs text-white rounded bg-emerald-700">Start Game</button>
-        <a routerLink="/lobby" class="text-xs underline text-emerald-200">Volver al lobby</a>
-      </div>
-    </div>
-
-    @if (error(); as err) {
-      <div class="px-4 py-2 mb-3 text-xs text-red-200 border border-red-400 rounded-md bg-red-900/40">
-        {{ err }}
-        <a routerLink="/lobby" class="ml-2 underline">Volver</a>
-      </div>
-    }
-
-    @if (joined()) {
-      <div class="grid grid-cols-1 gap-4 lg:grid-cols-3">
-        <div class="lg:col-span-2">
-          <app-room-canvas />
+    @if (room$ | async as room) {
+      <div class="flex items-center justify-between mb-4">
+        <h1 class="pixel-title">BATTLE TANKS · SALA</h1>
+        <div class="flex items-center space-x-2">
+          @if (room.status === 'Waiting') {
+            <button (click)="onStartGame()" class="px-2 py-1 text-xs text-white rounded bg-emerald-700">Start Game</button>
+          }
+          <a routerLink="/lobby" class="text-xs underline text-emerald-200">Volver al lobby</a>
         </div>
-        <div>
-          <div class="p-2 mb-4 rounded bg-emerald-800/30 text-emerald-100">
-            <h2 class="mb-2 text-xs font-bold">Jugadores</h2>
-            @for (p of players(); track p.playerId) {
-              <div class="flex justify-between text-xs">
-                <span>{{ p.username }}</span>
-                <span>❤️ {{ p.lives ?? 3 }} · ⭐ {{ p.score ?? 0 }}</span>
-              </div>
-            }
+      </div>
+
+      @if (room.error; as err) {
+        <div class="px-4 py-2 mb-3 text-xs text-red-200 border border-red-400 rounded-md bg-red-900/40">
+          {{ err }}
+          <a routerLink="/lobby" class="ml-2 underline">Volver</a>
+        </div>
+      }
+
+      @if (room.joined) {
+        <div class="grid grid-cols-1 gap-4 lg:grid-cols-3">
+          <div class="lg:col-span-2">
+            <app-room-canvas />
           </div>
-          <app-chat-panel />
+          <div>
+            <div class="p-2 mb-4 rounded bg-emerald-800/30 text-emerald-100">
+              <h2 class="mb-2 text-xs font-bold">Jugadores</h2>
+              @for (p of players$ | async; track p.playerId) {
+                <div class="flex justify-between text-xs">
+                  <span>{{ p.username }}</span>
+                  <span>❤️ {{ p.lives ?? 3 }} · ⭐ {{ p.score ?? 0 }}</span>
+                </div>
+              }
+            </div>
+            <app-chat-panel />
+          </div>
         </div>
-      </div>
-    } @else {
-      <div class="text-sm text-emerald-200">Conectando a la sala...</div>
+      } @else {
+        <div class="text-sm text-emerald-200">Conectando a la sala...</div>
+      }
     }
 
     <div class="scanline"></div>

--- a/frontend/BattleTanks-Frontend/src/app/features/room/store/room.actions.ts
+++ b/frontend/BattleTanks-Frontend/src/app/features/room/store/room.actions.ts
@@ -30,6 +30,13 @@ export const roomActions = createActionGroup({
     'Leave Room': emptyProps(),
     'Left': emptyProps(),
 
+    'Start Game': props<{ roomId: string }>(),
+    'Start Game Success': emptyProps(),
+    'Start Game Failure': props<{ error: string }>(),
+    'End Game': props<{ roomId: string }>(),
+    'End Game Success': emptyProps(),
+    'End Game Failure': props<{ error: string }>(),
+
     // Snapshots nuevos
     'Room Snapshot Received': props<{ snapshot: RoomSnapshotDto }>(),
     'Map Snapshot Received': props<{ snapshot: MapSnapshotDto }>(),

--- a/frontend/BattleTanks-Frontend/src/app/features/room/store/room.effects.spec.ts
+++ b/frontend/BattleTanks-Frontend/src/app/features/room/store/room.effects.spec.ts
@@ -35,6 +35,8 @@ class SignalRServiceMock {
 class RoomServiceMock {
   getRooms = jasmine.createSpy('getRooms').and.returnValue(of({ items: [] }));
   getRoom  = jasmine.createSpy('getRoom').and.returnValue(of(null));
+  startGame = jasmine.createSpy('startGame').and.returnValue(of(void 0));
+  endGame   = jasmine.createSpy('endGame').and.returnValue(of(void 0));
 }
 
 describe('RoomEffects (simple)', () => {

--- a/frontend/BattleTanks-Frontend/src/app/features/room/store/room.effects.ts
+++ b/frontend/BattleTanks-Frontend/src/app/features/room/store/room.effects.ts
@@ -116,6 +116,45 @@ export class RoomEffects {
     { dispatch: false }
   );
 
+  startGame$ = createEffect(() =>
+    this.actions$.pipe(
+      ofType(roomActions.startGame),
+      switchMap(({ roomId }) =>
+        this.roomsHttp.startGame(roomId).pipe(
+          map(() => {
+            alert('Juego iniciado');
+            return roomActions.startGameSuccess();
+          }),
+          catchError((err) =>
+            of(
+              roomActions.startGameFailure({
+                error: err?.error?.message ?? 'No se pudo iniciar el juego',
+              })
+            )
+          )
+        )
+      )
+    )
+  );
+
+  endGame$ = createEffect(() =>
+    this.actions$.pipe(
+      ofType(roomActions.endGame),
+      switchMap(({ roomId }) =>
+        this.roomsHttp.endGame(roomId).pipe(
+          map(() => roomActions.endGameSuccess()),
+          catchError((err) =>
+            of(
+              roomActions.endGameFailure({
+                error: err?.error?.message ?? 'No se pudo finalizar el juego',
+              })
+            )
+          )
+        )
+      )
+    )
+  );
+
   leave$ = createEffect(
     () =>
       this.actions$.pipe(

--- a/frontend/BattleTanks-Frontend/src/app/features/room/store/room.reducer.spec.ts
+++ b/frontend/BattleTanks-Frontend/src/app/features/room/store/room.reducer.spec.ts
@@ -9,6 +9,7 @@ describe('Room Reducer', () => {
     initial = {
       roomId: null,
       roomCode: null,
+      status: 'Waiting' as any,
       joined: false,
       hubConnected: false,
       error: null,
@@ -17,6 +18,7 @@ describe('Room Reducer', () => {
       powerUps: roomPowerUpsAdapter.getInitialState(),
       chat: [],
       lastUsername: null,
+      gameResult: null,
       map: null,
     };
   });

--- a/frontend/BattleTanks-Frontend/src/app/features/room/store/room.selectors.spec.ts
+++ b/frontend/BattleTanks-Frontend/src/app/features/room/store/room.selectors.spec.ts
@@ -20,6 +20,7 @@ describe('Room Selectors', () => {
     const room: RoomState = {
       roomId: 'r1',
       roomCode: 'ABCD',
+      status: 'Waiting' as any,
       joined: true,
       hubConnected: true,
       error: null,
@@ -28,6 +29,7 @@ describe('Room Selectors', () => {
       powerUps,
       chat: [],
       lastUsername: 'juan',
+      gameResult: null,
       map: null,
     };
     state = { room };

--- a/frontend/BattleTanks-Frontend/src/app/features/room/store/room.selectors.ts
+++ b/frontend/BattleTanks-Frontend/src/app/features/room/store/room.selectors.ts
@@ -1,25 +1,27 @@
 import { createFeatureSelector, createSelector } from '@ngrx/store';
 import { roomBulletsAdapter, roomPlayersAdapter, roomPowerUpsAdapter, RoomState } from './room.reducer';
 
-export const selectRoomState = createFeatureSelector<RoomState>('room');
+export const selectRoom = createFeatureSelector<RoomState>('room');
 
-export const selectRoomCode = createSelector(selectRoomState, (s) => s.roomCode);
-export const selectRoomId = createSelector(selectRoomState, (s) => s.roomId);
-export const selectHubConnected = createSelector(selectRoomState, (s) => s.hubConnected);
-export const selectJoined = createSelector(selectRoomState, (s) => s.joined);
-export const selectRoomError = createSelector(selectRoomState, (s) => s.error);
-export const selectChat = createSelector(selectRoomState, (s) => s.chat);
-export const selectGameResult = createSelector(selectRoomState, (s) => s.gameResult);
+export const selectRoomCode = createSelector(selectRoom, (s) => s.roomCode);
+export const selectRoomId = createSelector(selectRoom, (s) => s.roomId);
+export const selectRoomStatus = createSelector(selectRoom, (s) => s.status);
+export const selectHubConnected = createSelector(selectRoom, (s) => s.hubConnected);
+export const selectJoined = createSelector(selectRoom, (s) => s.joined);
+export const selectRoomError = createSelector(selectRoom, (s) => s.error);
+export const selectChat = createSelector(selectRoom, (s) => s.chat);
+export const selectGameResult = createSelector(selectRoom, (s) => s.gameResult);
 
 const playersSelectors = roomPlayersAdapter.getSelectors();
 const bulletsSelectors = roomBulletsAdapter.getSelectors();
 const powerUpsSelectors = roomPowerUpsAdapter.getSelectors();
 
-export const selectPlayers = createSelector(selectRoomState, (s) => playersSelectors.selectAll(s.players));
-export const selectBullets = createSelector(selectRoomState, (s) => bulletsSelectors.selectAll(s.bullets));
-export const selectPowerUps = createSelector(selectRoomState, (s) => powerUpsSelectors.selectAll(s.powerUps));
+export const selectPlayers = createSelector(selectRoom, (s) => playersSelectors.selectAll(s.players));
+export const selectAlivePlayers = createSelector(selectPlayers, (players) => players.filter((p) => (p.lives ?? 0) > 0));
+export const selectBullets = createSelector(selectRoom, (s) => bulletsSelectors.selectAll(s.bullets));
+export const selectPowerUps = createSelector(selectRoom, (s) => powerUpsSelectors.selectAll(s.powerUps));
 
-export const selectMap = createSelector(selectRoomState, (s) => s.map);
+export const selectMap = createSelector(selectRoom, (s) => s.map);
 export const selectMapSize = createSelector(selectMap, (m) => ({
   width: m?.width ?? 0,
   height: m?.height ?? 0,


### PR DESCRIPTION
## Summary
- add REST endpoints for starting and ending games
- manage game lifecycle through NgRx actions, selectors and effects
- show Start Game and logout controls using new Angular directives

## Testing
- `npm test --silent` *(fails: No binary for Chrome browser on your platform)*

------
https://chatgpt.com/codex/tasks/task_e_68bde94662c0832e82a0dd75f4e98272