### PR TITLE
Handle start and end game without tracking conflicts

### DIFF
--- a/backend/BattleTanks-Backend/Application/Interfaces/IPlayerRepository.cs
+++ b/backend/BattleTanks-Backend/Application/Interfaces/IPlayerRepository.cs
@@ -1,4 +1,5 @@
 using Domain.Entities;
+using System.Collections.Generic;
 
 namespace Application.Interfaces;
 
@@ -11,6 +12,7 @@ public interface IPlayerRepository
     Task<Player?> GetActivePlayerByUserIdAsync(Guid userId);
     Task AddAsync(Player player);
     Task UpdateAsync(Player player);
+    Task UpdateRangeAsync(IEnumerable<Player> players);
     Task DeleteAsync(Guid id);
     Task DeleteByUserIdAsync(Guid userId);
 }

--- a/backend/BattleTanks-Backend/Application/Services/GameService.cs
+++ b/backend/BattleTanks-Backend/Application/Services/GameService.cs
@@ -4,6 +4,7 @@ using Domain.Entities;
 using Domain.Enums;
 using System.Collections.Generic;
 using Infrastructure.SignalR.Abstractions;
+using System.Linq;
 
 namespace Application.Services;
 
@@ -201,6 +202,7 @@ public class GameService : IGameService
         if (session.Status != GameRoomStatus.InProgress)
             return null;
 
+        await _playerRepository.UpdateRangeAsync(session.Players);
         await _gameSessionRepository.UpdateAsync(session);
 
         var roomState = MapToRoomStateDto(session);
@@ -295,6 +297,8 @@ public class GameService : IGameService
                 player.RegisterDeath();
             }
         }
+
+        await _playerRepository.UpdateRangeAsync(session.Players);
 
         session.EndGame();
         await _gameSessionRepository.UpdateAsync(session);

--- a/backend/BattleTanks-Backend/Infrastructure/Persistence/Repositories/EfGameSessionRepository.cs
+++ b/backend/BattleTanks-Backend/Infrastructure/Persistence/Repositories/EfGameSessionRepository.cs
@@ -2,6 +2,7 @@ using Application.Interfaces;
 using Domain.Entities;
 using Domain.Enums;
 using System.Collections.Generic;
+using System.Linq;
 using Microsoft.EntityFrameworkCore;
 
 namespace Infrastructure.Persistence.Repositories;
@@ -18,6 +19,7 @@ public class EfGameSessionRepository : IGameSessionRepository
     public async Task<GameSession?> GetByIdAsync(Guid id)
     {
         return await _context.GameSessions
+            .AsNoTracking()
             .Include(gs => gs.Players).ThenInclude(p => p.User)
             .Include(gs => gs.Scores)
             .FirstOrDefaultAsync(gs => gs.Id == id);
@@ -73,23 +75,15 @@ public class EfGameSessionRepository : IGameSessionRepository
 
     public async Task UpdateAsync(GameSession session)
     {
-        var existing = _context.GameSessions.Local.FirstOrDefault(gs => gs.Id == session.Id)
-                       ?? await _context.GameSessions.FirstOrDefaultAsync(gs => gs.Id == session.Id);
+        var affected = await _context.GameSessions
+            .Where(gs => gs.Id == session.Id)
+            .ExecuteUpdateAsync(setters => setters
+                .SetProperty(gs => gs.Status, session.Status)
+                .SetProperty(gs => gs.StartedAt, session.StartedAt)
+                .SetProperty(gs => gs.EndedAt, session.EndedAt));
 
-        if (existing == null)
+        if (affected == 0)
             throw new KeyNotFoundException("Game session not found");
-
-        if (!ReferenceEquals(existing, session))
-        {
-            existing.Status = session.Status;
-            existing.StartedAt = session.StartedAt;
-            existing.EndedAt = session.EndedAt;
-        }
-
-        if (_context.Entry(existing).State == EntityState.Unchanged)
-            return;
-
-        await _context.SaveChangesAsync();
     }
 
     public async Task DeleteAsync(Guid id)

--- a/backend/BattleTanks-Backend/Infrastructure/Persistence/Repositories/EfPlayerRepository.cs
+++ b/backend/BattleTanks-Backend/Infrastructure/Persistence/Repositories/EfPlayerRepository.cs
@@ -2,6 +2,7 @@ using Application.Interfaces;
 using Domain.Entities;
 using EFCore.BulkExtensions;
 using Microsoft.EntityFrameworkCore;
+using System.Collections.Generic;
 
 namespace Infrastructure.Persistence.Repositories;
 
@@ -67,7 +68,25 @@ public class EfPlayerRepository : IPlayerRepository
 
     public async Task UpdateAsync(Player player)
     {
-        _context.Players.Update(player);
+        var existing = await _context.Players.FindAsync(player.Id);
+        if (existing is null)
+            throw new KeyNotFoundException("Player not found");
+
+        _context.Entry(existing).CurrentValues.SetValues(player);
+        await _context.SaveChangesAsync();
+    }
+
+    public async Task UpdateRangeAsync(IEnumerable<Player> players)
+    {
+        foreach (var player in players)
+        {
+            var existing = await _context.Players.FindAsync(player.Id);
+            if (existing is null)
+                throw new KeyNotFoundException("Player not found");
+
+            _context.Entry(existing).CurrentValues.SetValues(player);
+        }
+
         await _context.SaveChangesAsync();
     }
 


### PR DESCRIPTION
## Summary
- avoid tracking sessions when loading game by id
- update game sessions using ExecuteUpdate to bypass stale tracking
- persist player resets and final states when starting or ending games
- batch player updates to prevent DbContext concurrency during game start and end

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(403 Forbidden: repository access denied)*

------
https://chatgpt.com/codex/tasks/task_e_68be5238b418832e87f66ff730738adb